### PR TITLE
Fix sequential package.json processing

### DIFF
--- a/src/hooks/usePackageData.tsx
+++ b/src/hooks/usePackageData.tsx
@@ -10,6 +10,8 @@ import semver from "semver";
 import type { PackageInfo, PackageJsonUpdate } from "../types.js";
 import { detectWorkspaces, getDisplayVersion } from "../utils.js";
 
+const PACKAGE_BATCH_SIZE = 3
+
 export function usePackageData() {
   const [packages, setPackages] = useState<PackageInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -38,8 +40,8 @@ export function usePackageData() {
         }
 
         // Process package.json files in small batches to avoid race conditions
-        for (let i = 0; i < tasks.length; i += 3) {
-          await Promise.all(tasks.slice(i, i + 3).map((task) => task()));
+        for (let i = 0; i < tasks.length; i += PACKAGE_BATCH_SIZE) {
+          await Promise.all(tasks.slice(i, i + PACKAGE_BATCH_SIZE).map((task) => task()));
         }
 
         //setPackages(pkgs);

--- a/src/hooks/usePackageData.tsx
+++ b/src/hooks/usePackageData.tsx
@@ -31,15 +31,15 @@ export function usePackageData() {
         // const pkgs: PackageInfo[] = [];
         // Create a concurrency limit with a lower number to prevent rate limiting
         const limit = pLimit(5);
-        const tasks: Promise<void>[] = [];
+        const tasks: Array<() => Promise<void>> = [];
 
         for (const pkgPath of packageJsonPaths) {
-          tasks.push(processPackageJson(pkgPath, setPackages, limit));
+          tasks.push(() => processPackageJson(pkgPath, setPackages, limit));
         }
 
-        // Process package.json files sequentially to avoid race conditions
+        // Process package.json files in small batches to avoid race conditions
         for (let i = 0; i < tasks.length; i += 3) {
-          await Promise.all(tasks.slice(i, i + 3));
+          await Promise.all(tasks.slice(i, i + 3).map((task) => task()));
         }
 
         //setPackages(pkgs);


### PR DESCRIPTION
## Summary
- queue `processPackageJson` calls so they actually run in batches

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Error: no test specified... moep moep)*

------
https://chatgpt.com/codex/tasks/task_e_686fda559408832fa15b280a3d6af3b5